### PR TITLE
why don't you just do it like this?

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ where
             "request",
             http.req.method = %req.method(),
             http.req.uri = %req.uri();
-            http.req.version = %req.version(),
+            http.req.version = ?req.version(),
         );
 
         self.service.call(req).instrument(span)


### PR DESCRIPTION
noticed a few things:

* relying on `Span::current()` for the request data seems unnecessary;
  why not just create a child span of the handler for the request?
  this way, the fields are always recorded on a span that defines them
  and you can record them directly in the macro rather than having to
  do multiple `record` calls (less efficient, since it roundrips through
  the dispatcher 4 times)
* you never instrumented the service's `call` future with the span, so
  the span context isn't propagated to anything inside the service
* you don't need `format!` (allocating a `String`) just to format the
  version with `Debug`
* you recorded the method twice, rather than the URI (looked like a 
  copy-paste error)